### PR TITLE
Allow easy psql db connection with "npm run db".

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "get-secrets": "ssh nest.bocoup.com \"cat /mnt/secrets/{rds,pombot-slack,pombot-db-dev}\" > ./.env",
+    "db": "source .env && PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER $DB_NAME",
     "start": "babel-node ./app",
     "start-dev": "grunt",
     "migrate": "careen",


### PR DESCRIPTION
```bash
$ npm run db

> pombot@0.0.1 db /Users/cowboy/repos/bocoup/pombot
> source .env && PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER $DB_NAME

psql (9.5.3, server 9.4.5)
SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256, compression: off)
Type "help" for help.

pombot_cowboy=>
```