### PR TITLE
Use bot name as command name, and add @name aliases. Closes #52.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-runtime": "^6.3.19",
     "bluebird": "^3.4.0",
     "careen": "^0.1.1",
-    "chatter": "^0.4.0",
+    "chatter": "^0.4.1",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
     "heredoc-tag": "^0.1.0",

--- a/src/pombot/index.js
+++ b/src/pombot/index.js
@@ -26,8 +26,10 @@ export default function createBot(token) {
       };
     },
     createMessageHandler(id, {channel}) {
+      // Bot userid and name.
+      const {botName, aliases} = this.getBotNameAndAliases();
       // Give command a name in public channels.
-      const name = channel.is_im ? null : 'pom';
+      const name = channel.is_im ? null : botName;
       // Helper method to format the given command name.
       const getCommand = cmd => name ? `${name} ${cmd}` : cmd;
 
@@ -42,6 +44,7 @@ export default function createBot(token) {
       }, createCommand({
         isParent: true,
         name,
+        aliases,
         icon: 'https://static.bocoup.com/pombot/tomato-512x512.png',
         description: `:tomato: Hi, I'm pombot!`,
       }, [


### PR DESCRIPTION
You should be able to, in a public channel or DM, address the bot with:

* `botname`
* `botname:`
* `@botname`
* `@botname:`

eg.

* `botname`
* `botname:`
* `botname: help`
* `@botname: i will do something`

Assitionally, in a DM, you should be able to omit the name/alias, eg.

* `help`
* `i will do something`